### PR TITLE
Remove dependency on 'user' cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,12 +3,10 @@ maintainer 'Nick Pegg'
 maintainer_email 'nick@nickpegg.com'
 license 'MIT'
 description 'Sets up users'
-version '0.3.2'
+version '0.3.3'
 
 source_url 'https://github.com/nickpegg/cookbook-np-users'
 issues_url 'https://github.com/nickpegg/cookbook-np-users/issues'
-
-depends 'user', '>= 0.6.0'
 
 supports 'arch'
 supports 'debian', '~> 11.0'

--- a/recipes/nick.rb
+++ b/recipes/nick.rb
@@ -4,7 +4,7 @@ home_dir = '/home/nick'
 
 apt_update
 
-package %w(git vim zsh)
+package %w(git sudo vim zsh)
 
 # python > 3.5 is required by dotbot
 if platform?('arch')
@@ -26,12 +26,32 @@ if node['np-users']['nick']['in_docker_group']
   groups << 'docker'
 end
 
-user_account 'nick' do
+user 'nick' do
   home home_dir
-  groups groups
   shell '/usr/bin/zsh'
-  ssh_keygen false
-  ssh_keys nick_ssh_keys
+end
+
+directory home_dir do
+  owner 'nick'
+  group 'nick'
+end
+
+groups.each do |group_name|
+  group group_name do
+    append true
+    members 'nick'
+  end
+end
+
+directory ::File.join(home_dir, '.ssh') do
+  owner 'nick'
+  group 'nick'
+end
+
+file ::File.join(home_dir, '.ssh/authorized_keys') do
+  owner 'nick'
+  group 'nick'
+  content nick_ssh_keys.join("\n")
 end
 
 # Set up dotfiles

--- a/recipes/rsaxvc.rb
+++ b/recipes/rsaxvc.rb
@@ -1,7 +1,24 @@
-user_account 'rsaxvc' do
-  ssh_keygen false
-  ssh_keys [
-    'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCe/XHXa8et9CxffrK4un2CD8oZkf+LmHaVE8M5PZcXuUP5Y+ETIrOMFHtlcunF7PEZja8rQEV5UdvdVX78wf8v6H4CVaodhfPdZm4fexFH096XgmAj1Tb8pY6y1Duf5xPZhseG0TczcxmNS4MBD2azrbbhvy8jzrnMGBePBgf+/QMungU8S3F4wJNvqmhUUfDh9JP+vS88wfFDh0xx0wUH5dcwc8uUryUnKo/oQiPf/Yh4qml3hPEh46HpsqFAoVEvBcSXx29G8jJDJlpCxD4qeOnQZU2E7ntyDRAeG585Gb1gwNVB/Uw2vUgTTejKzLnY7XyYgN6T1kJF68AQg7hD rsaxvc@rsaxvc.net',
-    'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDiNpfQ8ciXqZF27W8E7j77rSb38uOlWZMqHnUsdMB0Jks9TR7pjd5TqYMGPvQkujsx55azlE44uJSPrU0swxRE1nX9zDkR13ldu0Pziy/0z2Kl2n6ffkh6docv1qDoMEswLdGmRYFegadyqxwqUqsh/NbKtAEL+9BBXchbKE8hT+dhwIzxNFAakaan7SycfNNrSqtAcq/bf/I6vDJWygfEg6If4R5rpsd9cwHWwMcWoHTrxMgVIE7RLJbIqO1zBPk4HVYceYucsp2rxcVgvocLeX/F5V3GYnXFWfH29DD++Raewbep0q5s+VKcfO4sSNBvnanYrAcGuiJlQf/aoN+d rsaxvc@gmail.com',
-  ]
+ssh_keys = [
+  'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCe/XHXa8et9CxffrK4un2CD8oZkf+LmHaVE8M5PZcXuUP5Y+ETIrOMFHtlcunF7PEZja8rQEV5UdvdVX78wf8v6H4CVaodhfPdZm4fexFH096XgmAj1Tb8pY6y1Duf5xPZhseG0TczcxmNS4MBD2azrbbhvy8jzrnMGBePBgf+/QMungU8S3F4wJNvqmhUUfDh9JP+vS88wfFDh0xx0wUH5dcwc8uUryUnKo/oQiPf/Yh4qml3hPEh46HpsqFAoVEvBcSXx29G8jJDJlpCxD4qeOnQZU2E7ntyDRAeG585Gb1gwNVB/Uw2vUgTTejKzLnY7XyYgN6T1kJF68AQg7hD rsaxvc@rsaxvc.net',
+  'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDiNpfQ8ciXqZF27W8E7j77rSb38uOlWZMqHnUsdMB0Jks9TR7pjd5TqYMGPvQkujsx55azlE44uJSPrU0swxRE1nX9zDkR13ldu0Pziy/0z2Kl2n6ffkh6docv1qDoMEswLdGmRYFegadyqxwqUqsh/NbKtAEL+9BBXchbKE8hT+dhwIzxNFAakaan7SycfNNrSqtAcq/bf/I6vDJWygfEg6If4R5rpsd9cwHWwMcWoHTrxMgVIE7RLJbIqO1zBPk4HVYceYucsp2rxcVgvocLeX/F5V3GYnXFWfH29DD++Raewbep0q5s+VKcfO4sSNBvnanYrAcGuiJlQf/aoN+d rsaxvc@gmail.com',
+]
+
+user 'rsaxvc' do
+  home '/home/rsaxvc'
+end
+
+directory '/home/rsaxvc' do
+  owner 'rsaxvc'
+  group 'rsaxvc'
+end
+
+directory ::File.join(home_dir, '.ssh') do
+  owner 'rsaxvc'
+  group 'rsaxvc'
+end
+
+file ::File.join(home_dir, '.ssh/authorized_keys') do
+  owner 'rsaxvc'
+  group 'rsaxvc'
+  content ssh_keys.join("\n")
 end

--- a/recipes/rsaxvc.rb
+++ b/recipes/rsaxvc.rb
@@ -1,13 +1,14 @@
+home_dir = '/home/rsaxvc'
 ssh_keys = [
   'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCe/XHXa8et9CxffrK4un2CD8oZkf+LmHaVE8M5PZcXuUP5Y+ETIrOMFHtlcunF7PEZja8rQEV5UdvdVX78wf8v6H4CVaodhfPdZm4fexFH096XgmAj1Tb8pY6y1Duf5xPZhseG0TczcxmNS4MBD2azrbbhvy8jzrnMGBePBgf+/QMungU8S3F4wJNvqmhUUfDh9JP+vS88wfFDh0xx0wUH5dcwc8uUryUnKo/oQiPf/Yh4qml3hPEh46HpsqFAoVEvBcSXx29G8jJDJlpCxD4qeOnQZU2E7ntyDRAeG585Gb1gwNVB/Uw2vUgTTejKzLnY7XyYgN6T1kJF68AQg7hD rsaxvc@rsaxvc.net',
   'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDiNpfQ8ciXqZF27W8E7j77rSb38uOlWZMqHnUsdMB0Jks9TR7pjd5TqYMGPvQkujsx55azlE44uJSPrU0swxRE1nX9zDkR13ldu0Pziy/0z2Kl2n6ffkh6docv1qDoMEswLdGmRYFegadyqxwqUqsh/NbKtAEL+9BBXchbKE8hT+dhwIzxNFAakaan7SycfNNrSqtAcq/bf/I6vDJWygfEg6If4R5rpsd9cwHWwMcWoHTrxMgVIE7RLJbIqO1zBPk4HVYceYucsp2rxcVgvocLeX/F5V3GYnXFWfH29DD++Raewbep0q5s+VKcfO4sSNBvnanYrAcGuiJlQf/aoN+d rsaxvc@gmail.com',
 ]
 
 user 'rsaxvc' do
-  home '/home/rsaxvc'
+  home home_dir
 end
 
-directory '/home/rsaxvc' do
+directory home_dir do
   owner 'rsaxvc'
   group 'rsaxvc'
 end

--- a/recipes/rsaxvc.rb
+++ b/recipes/rsaxvc.rb
@@ -6,6 +6,7 @@ ssh_keys = [
 
 user 'rsaxvc' do
   home home_dir
+  shell "/bin/bash"
 end
 
 directory home_dir do

--- a/recipes/rsaxvc.rb
+++ b/recipes/rsaxvc.rb
@@ -6,7 +6,7 @@ ssh_keys = [
 
 user 'rsaxvc' do
   home home_dir
-  shell "/bin/bash"
+  shell '/bin/bash'
 end
 
 directory home_dir do

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,17 +1,3 @@
-# Check stuff that should have been done by user::data_bag
-describe user('nick') do
-  it { should exist }
-  its('groups') { should include 'nick' }
-  its('groups') { should include 'sudo' }
-  its('groups') { should_not include 'docker' }
-  its('shell') { should eq '/usr/bin/zsh' }
-end
-
-describe file('/home/nick/.ssh/authorized_keys') do
-  its('content') { should match 'nick@polo' }
-  its('content') { should match 'mr8= test key' }
-end
-
 describe user('rsaxvc') do
   it { should exist }
   its('groups') { should include 'rsaxvc' }

--- a/test/integration/default/nick_spec.rb
+++ b/test/integration/default/nick_spec.rb
@@ -1,3 +1,19 @@
+describe user('nick') do
+  it { should exist }
+  its('groups') { should include 'nick' }
+  its('groups') { should include 'sudo' }
+  its('groups') { should_not include 'docker' }
+  its('shell') { should eq '/usr/bin/zsh' }
+end
+
+describe file('/home/nick/.ssh/authorized_keys') do
+  it { should be_owned_by 'nick' }
+  it { should be_writable.by('owner') }
+  it { should_not be_writable.by('others') }
+  its('content') { should match 'nick@polo' }
+  its('content') { should match 'mr8= test key' }
+end
+
 # Make sure dotfiles exist
 describe file '/home/nick/.zshrc' do
   it { should exist }


### PR DESCRIPTION
This cookbook hasn't received any updates in years and has a deprecation
warning that it'll fail in Chef 18, so just manage users using the stdlib
resources.
